### PR TITLE
bump version to 2.1.0

### DIFF
--- a/addons/sourcemod/scripting/FunModes.sp
+++ b/addons/sourcemod/scripting/FunModes.sp
@@ -97,6 +97,12 @@ public void OnPluginEnd()
 		
 		OnClientDisconnect(i);
 	}
+
+	// TODO: Move this to GunGame.sp, the next version will clean this
+	if (g_cvZRRestrictPerPlayer == null)
+		return;
+
+	g_cvZRRestrictPerPlayer.BoolValue = g_bZRRestrictPerPlayer;
 }
 
 public void OnMapStart()

--- a/addons/sourcemod/scripting/FunModes.sp
+++ b/addons/sourcemod/scripting/FunModes.sp
@@ -97,12 +97,6 @@ public void OnPluginEnd()
 		
 		OnClientDisconnect(i);
 	}
-
-	// TODO: Move this to GunGame.sp, the next version will clean this
-	if (g_cvZRRestrictPerPlayer == null)
-		return;
-
-	g_cvZRRestrictPerPlayer.BoolValue = g_bZRRestrictPerPlayer;
 }
 
 public void OnMapStart()
@@ -130,7 +124,7 @@ public void OnClientDisconnect(int client)
 {
 	g_bSDKHook_OnTakeDamagePost[client] = false;
 	g_bSDKHook_OnTakeDamage[client] = false;
-	g_bSDKHook_WeaponCanUse[client] = false;
+	g_bSDKHook_WeaponEquip[client] = false;
 	DECLARE_FM_FORWARD_PARAM(OnClientDisconnect, client);
 }
 
@@ -186,11 +180,11 @@ Action OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, in
 	return result;
 }
 
-Action OnWeaponCanUse(int client, int weapon)
+Action OnWeaponEquip(int client, int weapon)
 {
 	Action result = Plugin_Continue;
 	
-	DECLARE_FM_FORWARD_PARAM3(OnWeaponCanUse, client, weapon, result);
+	DECLARE_FM_FORWARD_PARAM3(OnWeaponEquip, client, weapon, result);
 	
 	return result;
 }

--- a/addons/sourcemod/scripting/Fun_Modes/BlindMode.sp
+++ b/addons/sourcemod/scripting/Fun_Modes/BlindMode.sp
@@ -214,7 +214,7 @@ void ApplyBlind(int client)
 	int color[4];
 	color[3] = 255;
 
-	int flags = FFADE_OUT;
+	int flags = FFADE_IN;
 	
 	int clients[1];
 	clients[0] = client;
@@ -273,17 +273,18 @@ Action Timer_BlindMode(Handle timer)
 	float percentage = THIS_MODE_INFO.cvarInfo[BLINDMODE_CONVAR_PERCENTAGE].cvar.FloatValue;
 	int neededZombies = RoundToCeil(zombiesCount * (percentage / 100));
 	
-	int enough = 0;
+	int enough = 1;
 	do 
 	{
 		int zombie = zombies[GetRandomInt(0, zombiesCount - 1)];
 		if (g_bHasFlash[zombie])
 			zombie = zombies[GetRandomInt(0, zombiesCount - 1)];
-			
+
 		g_bHasFlash[zombie] = true;
+		
 		int entity = GivePlayerItem(zombie, "weapon_flashbang");
 		EquipPlayerWeapon(zombie, entity);
-		SetEntData(zombie, FindSendPropInfo("CBasePlayer", "m_iAmmo") + (view_as<int>(GrenadeType_Flashbang) * 4), 1, _, true);
+
 		CPrintToChat(zombie, "%s You have been granted a FlashBang!!!\nBlind some humans.", THIS_MODE_INFO.tag);
 		enough++;
 	} while (enough <= neededZombies);
@@ -315,6 +316,7 @@ Action Timer_ApplyBlind(Handle timer, int ref)
 	GetEntPropVector(entity, Prop_Send, "m_vecOrigin", origin);
 
 	float maxDistance = THIS_MODE_INFO.cvarInfo[BLINDMODE_CONVAR_MAX_DISTANCE].cvar.FloatValue;
+	maxDistance *= maxDistance;
 	
 	for (int i = 1; i <= MaxClients; i++)
 	{
@@ -324,7 +326,7 @@ Action Timer_ApplyBlind(Handle timer, int ref)
 		float plOrigin[3];
 		GetClientAbsOrigin(i, plOrigin);
 		
-		float distance = GetVectorDistance(origin, plOrigin);
+		float distance = GetVectorDistance(origin, plOrigin, true);
 		if (distance > maxDistance)
 			continue;
 		

--- a/addons/sourcemod/scripting/Fun_Modes/Core.sp
+++ b/addons/sourcemod/scripting/Fun_Modes/Core.sp
@@ -17,7 +17,7 @@ bool g_bEvent_WeaponFire;
 
 /* Client SDKHook Boolens */
 bool g_bSDKHook_OnTakeDamagePost[MAXPLAYERS + 1] = { false, ... };
-bool g_bSDKHook_WeaponEquip[MAXPLAYERS + 1] =  { false, ... };
+bool g_bSDKHook_WeaponCanUse[MAXPLAYERS + 1] =  { false, ... };
 bool g_bSDKHook_OnTakeDamage[MAXPLAYERS + 1] =  { false, ... };
 
 /* Round Checking Booleans */
@@ -45,6 +45,7 @@ int g_iCounter = 0;
 /* GLOBAL CONVARS */
 ConVar g_cvHUDChannel;
 int g_iPreviousModeIndex[MAXPLAYERS+1];
+int g_iNetPropAmmoIndex = -1;
 
 /* SDKCall Handles */
 Handle g_hSwitchSDKCall;
@@ -105,6 +106,13 @@ enum WeaponAmmoGrenadeType
 	GrenadeType_Smokegrenade        = 13,   /** CSS - Smokegrenade slot. */
 };
 
+#define HEGRENADE			11
+#define FLASHBANG			12
+#define SMOKEGRENADE		13
+
+#define GET_GRENADES_COUNT(%1,%2)		GetEntData(%1, g_iNetPropAmmoIndex + (%2 * 4))
+#define SET_GRENADES_COUNT(%1,%2,%3)	SetEntData(%1, g_iNetPropAmmoIndex + (%2 * 4), %3, _, true)			
+		
 /* 
 - New FunModes Update
 	* The plugin will now use macros to define the main functions and forwards
@@ -135,7 +143,6 @@ enum WeaponAmmoGrenadeType
 		CALL_MODE_FUNC(%1, RealityShift); \
 		CALL_MODE_FUNC(%1, PullGame)
 
-#define CALL_MODE_FUNC_PARAM(%1,%2,%3) %1_%2(%3)
 #define DECLARE_FM_FORWARD_PARAM(%1,%2) \
 		CALL_MODE_FUNC_PARAM(%1, HealBeacon, %2); \ 
 		CALL_MODE_FUNC_PARAM(%1, VIPMode, %2); \
@@ -149,6 +156,7 @@ enum WeaponAmmoGrenadeType
 		CALL_MODE_FUNC_PARAM(%1, CrazyShop, %2); \
 		CALL_MODE_FUNC_PARAM(%1, RealityShift, %2); \
 		CALL_MODE_FUNC_PARAM(%1, PullGame, %2)
+#define CALL_MODE_FUNC_PARAM(%1,%2,%3) %1_%2(%3)
 
 /*
 these commented macros are not used for now
@@ -180,7 +188,8 @@ these commented macros are not used for now
 #define DECLARE_ONPLAYERRUNCMD_POST(%1,%2,%3,%4) \
 		CALL_MODE_FUNC_PARAM3(%1, DoubleJump, %2, %3, %4); \
 		CALL_MODE_FUNC_PARAM3(%1, CrazyShop, %2, %3, %4); \
-		CALL_MODE_FUNC_PARAM3(%1, PullGame, %2, %3, %4)
+		CALL_MODE_FUNC_PARAM3(%1, PullGame, %2, %3, %4); \
+		CALL_MODE_FUNC_PARAM3(%1, ChaosWeapons, %2, %3, %4)
 		
 /* %0: ConVarInfo[], %1: index, %2: name, %3: default value, %4: description 
 	%5: cvar values, %6: cvar value type
@@ -194,6 +203,8 @@ these commented macros are not used for now
 #define CHANGE_MODE_INFO(%1,%2,%3,%4) \ 
 		%1.%2 = %3; \
 		g_ModesInfo[%4] = %1
+
+#define FUNMODE_CONVAR(%1,%2) %1.cvarInfo[%2].cvar
 
 #define THIS_MODE_INFO
 

--- a/addons/sourcemod/scripting/Fun_Modes/Core.sp
+++ b/addons/sourcemod/scripting/Fun_Modes/Core.sp
@@ -17,7 +17,7 @@ bool g_bEvent_WeaponFire;
 
 /* Client SDKHook Boolens */
 bool g_bSDKHook_OnTakeDamagePost[MAXPLAYERS + 1] = { false, ... };
-bool g_bSDKHook_WeaponCanUse[MAXPLAYERS + 1] =  { false, ... };
+bool g_bSDKHook_WeaponEquip[MAXPLAYERS + 1] =  { false, ... };
 bool g_bSDKHook_OnTakeDamage[MAXPLAYERS + 1] =  { false, ... };
 
 /* Round Checking Booleans */
@@ -204,7 +204,9 @@ these commented macros are not used for now
 		%1.%2 = %3; \
 		g_ModesInfo[%4] = %1
 
+/*
 #define FUNMODE_CONVAR(%1,%2) %1.cvarInfo[%2].cvar
+*/
 
 #define THIS_MODE_INFO
 

--- a/addons/sourcemod/scripting/Fun_Modes/CrazyShop.sp
+++ b/addons/sourcemod/scripting/Fun_Modes/CrazyShop.sp
@@ -400,7 +400,7 @@ stock void OnTakeDamagePost_CrazyShop(int victim, int attacker, float damage)
 	}
 }
 
-stock void OnWeaponCanUse_CrazyShop(int client, int weapon, Action &result)
+stock void OnWeaponEquip_CrazyShop(int client, int weapon, Action &result)
 {
 	#pragma unused client
 	#pragma unused weapon

--- a/addons/sourcemod/scripting/Fun_Modes/DamageGame.sp
+++ b/addons/sourcemod/scripting/Fun_Modes/DamageGame.sp
@@ -154,7 +154,7 @@ stock void OnTakeDamagePost_DamageGame(int victim, int attacker, float damage)
 	g_iDealtDamage[attacker] += RoundToNearest(damage);
 }
 
-stock void OnWeaponEquip_DamageGame(int client, int weapon, Action &result)
+stock void OnWeaponCanUse_DamageGame(int client, int weapon, Action &result)
 {
 	#pragma unused client
 	#pragma unused weapon
@@ -190,7 +190,7 @@ public Action Cmd_DamageGameToggle(int client, int args)
 			OnClientPutInServer_DamageGame(i);
 		}
 		
-		CS_TerminateRound(3.0, CSRoundEnd_Draw);
+		FunModes_RestartRound();
 	}
 	else
 	{

--- a/addons/sourcemod/scripting/Fun_Modes/DamageGame.sp
+++ b/addons/sourcemod/scripting/Fun_Modes/DamageGame.sp
@@ -154,7 +154,7 @@ stock void OnTakeDamagePost_DamageGame(int victim, int attacker, float damage)
 	g_iDealtDamage[attacker] += RoundToNearest(damage);
 }
 
-stock void OnWeaponCanUse_DamageGame(int client, int weapon, Action &result)
+stock void OnWeaponEquip_DamageGame(int client, int weapon, Action &result)
 {
 	#pragma unused client
 	#pragma unused weapon

--- a/addons/sourcemod/scripting/Fun_Modes/DoubleJump.sp
+++ b/addons/sourcemod/scripting/Fun_Modes/DoubleJump.sp
@@ -27,7 +27,8 @@ stock void OnPluginStart_DoubleJump()
 
 	/* ADMIN COMMANDS */
 	RegAdminCmd("sm_fm_doublejump", Cmd_DoubleJumpToggle, ADMFLAG_CONVARS, "Enable/Disable Double Jump mode.");
-
+	RegAdminCmd("sm_doublejump_settings", Cmd_DoubleJumpSettings, ADMFLAG_CONFIG, "Open DoubleJump Settings Menu");
+	
 	/* CONVARS */
 	DECLARE_FM_CVAR(
 		THIS_MODE_INFO.cvarInfo, DOUBLEJUMP_CONVAR_BOOST,

--- a/addons/sourcemod/scripting/Fun_Modes/DoubleJump.sp
+++ b/addons/sourcemod/scripting/Fun_Modes/DoubleJump.sp
@@ -187,7 +187,7 @@ stock void ApplyNewJump(int client)
 }
 
 /* DoubleJump Settings */
-public void Cmd_DoubleJumpSettings(int client)
+public Action Cmd_DoubleJumpSettings(int client, int args)
 {
 	Menu menu = new Menu(Menu_DoubleJumpSettings);
 
@@ -197,6 +197,7 @@ public void Cmd_DoubleJumpSettings(int client)
 
 	menu.ExitBackButton = true;
 	menu.Display(client, MENU_TIME_FOREVER);
+	return Plugin_Handled;
 }
 
 int Menu_DoubleJumpSettings(Menu menu, MenuAction action, int param1, int param2)

--- a/addons/sourcemod/scripting/Fun_Modes/Fog.sp
+++ b/addons/sourcemod/scripting/Fun_Modes/Fog.sp
@@ -13,10 +13,12 @@ ModeInfo g_FogInfo;
 #undef THIS_MODE_INFO
 #define THIS_MODE_INFO g_FogInfo
 
-#define FOGInput_Color 0
-#define FOGInput_Start 1
-#define FOGInput_End 2
+#define FOGInput_Color 	0
+#define FOGInput_Start 	1
+#define FOGInput_End 	2
 #define FOGInput_Toggle 3
+
+#define FOG_NAME		"fog_mode_aaa34124n"
 
 enum struct fogData
 {
@@ -110,7 +112,7 @@ stock void Event_RoundStart_Fog()
 			if (!IsClientInGame(i))
 				continue;
 
-			SetVariantString("fog_mode_aaa34124n");
+			SetVariantString(FOG_NAME);
 			AcceptEntityInput(i, "SetFogController");
 		}
 
@@ -123,6 +125,9 @@ stock void Event_RoundStart_Fog()
 stock void Event_RoundEnd_Fog() {}
 stock void Event_PlayerSpawn_Fog(int client)
 {
+	if (!THIS_MODE_INFO.isOn)
+		return;
+		
 	CreateTimer(1.0, PlayerSpawn_Timer, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
 }
 
@@ -138,11 +143,14 @@ stock void Event_PlayerDeath_Fog(int client)
 
 Action PlayerSpawn_Timer(Handle timer, int userid)
 {
+	if (!THIS_MODE_INFO.isOn)
+		return Plugin_Stop;
+		
 	int client = GetClientOfUserId(userid);
-	if (client < 1 || !THIS_MODE_INFO.isOn)
+	if (client < 1)
 		return Plugin_Stop;
 
-	SetVariantString("fog_mode_aaa34124n");
+	SetVariantString(FOG_NAME);
 	AcceptEntityInput(client, "SetFogController");
 	return Plugin_Continue;
 }
@@ -151,7 +159,7 @@ stock void CreateFogEntity()
 {
 	/* CHECK FOR ANY FOG MAP HAS */
 	int entity = -1;
-	while((entity = FindEntityByClassname(entity, "env_fog_controller")) != -1)
+	while ((entity = FindEntityByClassname(entity, "env_fog_controller")) != -1)
 	{
 		if (entity == g_iFogEntity)
 			continue;
@@ -169,7 +177,7 @@ stock void CreateFogEntity()
 	if (!IsValidEntity(g_iFogEntity))
 		return;
 	
-	DispatchKeyValue(g_iFogEntity, "targetname", "fog_mode_aaa34124n");
+	DispatchKeyValue(g_iFogEntity, "targetname", FOG_NAME);
 	DispatchKeyValue(g_iFogEntity, "fogenable", "1");
 	DispatchKeyValue(g_iFogEntity, "fogblend", "1");
 	DispatchKeyValueFloat(g_iFogEntity, "fogstart", g_FogData.fogStart);
@@ -186,7 +194,7 @@ stock void CreateFogEntity()
 		if (!IsClientInGame(i))
 			continue;
 
-		SetVariantString("fog_mode_aaa34124n");
+		SetVariantString(FOG_NAME);
 		AcceptEntityInput(i, "SetFogController");
 	}
 }
@@ -200,8 +208,8 @@ stock void AcceptFogInput(int mode)
 	{
 		case FOGInput_Color:
 		{
-			char sColor[64];
-			Format(sColor, sizeof(sColor), "%i %i %i %i", g_FogData.fogColor[0], g_FogData.fogColor[1], g_FogData.fogColor[2], g_FogData.fogColor[3]);
+			char sColor[20];
+			FormatEx(sColor, sizeof(sColor), "%i %i %i %i", g_FogData.fogColor[0], g_FogData.fogColor[1], g_FogData.fogColor[2], g_FogData.fogColor[3]);
 
 			SetVariantString(sColor);
 			AcceptEntityInput(g_iFogEntity, "SetColor");
@@ -403,6 +411,7 @@ public Action Cmd_FogToggle(int client, int args)
 		FunModes_HookEvent(g_bEvent_PlayerSpawn, "player_spawn", Event_PlayerSpawn);
 		CReplyToCommand(client, "%s FOG Mode is now {olive}ON!", THIS_MODE_INFO.tag);
 		CreateFogEntity();
+		AcceptFogInput(FOGInput_Toggle);
 		return Plugin_Handled;
 	}
 }

--- a/addons/sourcemod/scripting/Fun_Modes/GunGame.sp
+++ b/addons/sourcemod/scripting/Fun_Modes/GunGame.sp
@@ -18,9 +18,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#undef REQUIRE_PLUGIN
-#tryinclude <EntWatch>
-#define REQUIRE_PLUGIN
+#include <EntWatch>
 
 #define _FM_GunGame
 
@@ -29,16 +27,16 @@ ModeInfo g_GunGameInfo;
 #undef THIS_MODE_INFO
 #define THIS_MODE_INFO g_GunGameInfo
 
-#define GUNGAME_CONVAR_PISTOLS_DAMAGE	0
-#define GUNGAME_CONVAR_SHOTGUNS_DAMAGE	1
-#define GUNGAME_CONVAR_SMGS_DAMAGE		2
-#define GUNGAME_CONVAR_RIFLES_DAMAGE	3
-#define GUNGAME_CONVAR_M249_DAMAGE		4
-#define GUNGAME_CONVAR_ENTWATCH			5
-#define GUNGAME_CONVAR_HEGRENADES_COUNT 6
-#define GUNGAME_CONVAR_REWARD_GRAVITY	7
-#define GUNGAME_CONVAR_REWARD_SPEED		8
-#define GUNGAME_CONVAR_TOGGLE 			9
+#define GUNGAME_CONVAR_PISTOLS_DAMAGE		0
+#define GUNGAME_CONVAR_SHOTGUNS_DAMAGE		1
+#define GUNGAME_CONVAR_SMGS_DAMAGE			2
+#define GUNGAME_CONVAR_RIFLES_DAMAGE		3
+#define GUNGAME_CONVAR_M249_DAMAGE			4
+#define GUNGAME_CONVAR_SMOKEGRENADES_COUNT 	5
+#define GUNGAME_CONVAR_REWARD_GRAVITY		6
+#define GUNGAME_CONVAR_REWARD_SPEED			7
+#define GUNGAME_CONVAR_CHANGE_WEAPON		8
+#define GUNGAME_CONVAR_TOGGLE 				9
 
 static const char g_GunGameWeaponsList[][][] =
 {
@@ -52,8 +50,7 @@ static const char g_GunGameWeaponsList[][][] =
 enum GunGame_Reward
 {
 	REWARD_SPEED = 0,
-	REWARD_GRAVITY,
-	REWARD_HEGRENADES,
+	REWARD_SMOKEGRENADES,
 	REWARD_NONE
 };
 
@@ -63,7 +60,6 @@ enum struct GunGame_Data
 	int dealtDamage;
 	
 	bool completedCycle;
-	bool allowEquip;
 	
 	float originalSpeed;
 	float originalGravity;
@@ -73,12 +69,15 @@ enum struct GunGame_Data
 	
 	void ResetLevel()
 	{
+		this.dealtDamage = 0;
 		this.level[0] = 0;
 		this.level[1] = 0;
 	}
 }
 
 GunGame_Data g_GunGameData[MAXPLAYERS + 1];
+
+StringMap g_hGunGameWeaponsMap;
 
 stock void OnPluginStart_GunGame()
 {
@@ -89,49 +88,43 @@ stock void OnPluginStart_GunGame()
 	/* THESE ARE THE STANDARD COMMANDS THAT ALL MODES SHOULD HAVE */
 	RegAdminCmd("sm_fm_gungame", Cmd_GunGameToggle, ADMFLAG_CONVARS, "Turn GunGame Mode On/Off");
 	RegAdminCmd("sm_gungame_settings", Cmd_GunGameSettings, ADMFLAG_CONVARS, "Open GunGame Sttings Menu");
-	
+
 	RegConsoleCmd("sm_gungame", Cmd_GunGame, "Get your original weapons");
 
 	/* CONVARS */
 	DECLARE_FM_CVAR(
 		THIS_MODE_INFO.cvarInfo, GUNGAME_CONVAR_PISTOLS_DAMAGE,
-		"sm_gungame_pistols_damage", "1200", "The required damage needed for pistols to upgrade",
+		"sm_gungame_pistols_damage", "400", "The required damage needed for pistols to upgrade",
 		("800,1000,1500,2000,2500"), "int"
 	);
 	
 	DECLARE_FM_CVAR(
 		THIS_MODE_INFO.cvarInfo, GUNGAME_CONVAR_SHOTGUNS_DAMAGE,
-		"sm_gungame_shotguns_damage", "2200", "The required damage needed for shotguns to upgrade",
+		"sm_gungame_shotguns_damage", "900", "The required damage needed for shotguns to upgrade",
 		("800,1000,1500,2000,2500"), "int"
 	);
 	
 	DECLARE_FM_CVAR(
 		THIS_MODE_INFO.cvarInfo, GUNGAME_CONVAR_SMGS_DAMAGE,
-		"sm_gungame_smgs_damage", "4200", "The required damage needed for smgs to upgrade",
+		"sm_gungame_smgs_damage", "1800", "The required damage needed for smgs to upgrade",
 		("800,1000,1500,2000,2500"), "int"
 	);
 	
 	DECLARE_FM_CVAR(
 		THIS_MODE_INFO.cvarInfo, GUNGAME_CONVAR_RIFLES_DAMAGE,
-		"sm_gungame_rifles_damage", "3800", "The required damage needed for rifles to upgrade",
+		"sm_gungame_rifles_damage", "2400", "The required damage needed for rifles to upgrade",
 		("800,1000,1500,2000,2500"), "int"
 	);
 	
 	DECLARE_FM_CVAR(
 		THIS_MODE_INFO.cvarInfo, GUNGAME_CONVAR_M249_DAMAGE,
-		"sm_gungame_m249_damage", "8000", "The required damage needed for m249 to finish the gungame cycle",
+		"sm_gungame_m249_damage", "4000", "The required damage needed for m249 to finish the gungame cycle",
 		("800,1000,1500,2000,2500"), "int"
 	);
 	
 	DECLARE_FM_CVAR(
-		THIS_MODE_INFO.cvarInfo, GUNGAME_CONVAR_ENTWATCH,
-		"sm_gungame_allow_entwatch", "0", "Allow entwatch items to be picked up (1 = Enabled, 0 = Disabled)",
-		("0,1"), "bool"
-	);
-	
-	DECLARE_FM_CVAR(
-		THIS_MODE_INFO.cvarInfo, GUNGAME_CONVAR_HEGRENADES_COUNT,
-		"sm_gungame_hegrenades_reward", "3", "How many hegrenades to give to the player when completing a cycle",
+		THIS_MODE_INFO.cvarInfo, GUNGAME_CONVAR_SMOKEGRENADES_COUNT,
+		"sm_gungame_smokegrenades_reward", "2", "How many smokegrenades to give to the player when completing a cycle",
 		("1,3,5,10,15"), "int"
 	);
 	
@@ -145,6 +138,12 @@ stock void OnPluginStart_GunGame()
 		THIS_MODE_INFO.cvarInfo, GUNGAME_CONVAR_REWARD_SPEED,
 		"sm_gungame_speed_reward", "100.0", "How many seconds can the player keep their high speed hold",
 		("20.0,30.0,40.0,60.0,80.0,100.0"), "float"
+	);
+	
+	DECLARE_FM_CVAR(
+		THIS_MODE_INFO.cvarInfo, GUNGAME_CONVAR_CHANGE_WEAPON,
+		"sm_gungame_allow_change_weapon", "0", "Enable/Disable allowing players to change their weapon to lower level",
+		("0,1"), "bool"
 	);
 	
 	DECLARE_FM_CVAR(
@@ -181,13 +180,12 @@ stock void OnClientPutInServer_GunGame(int client)
 	if (!THIS_MODE_INFO.isOn)
 		return;
 	
-	g_GunGameData[client].allowEquip = true;
 	g_GunGameData[client].ResetLevel();
 	
-	if (!g_bSDKHook_WeaponEquip[client])
+	if (!g_bSDKHook_WeaponCanUse[client])
 	{
-		SDKHook(client, SDKHook_WeaponEquip, OnWeaponEquip);
-		g_bSDKHook_WeaponEquip[client] = true;
+		SDKHook(client, SDKHook_WeaponCanUse, OnWeaponCanUse);
+		g_bSDKHook_WeaponCanUse[client] = true;
 	}
 	
 	if (!g_bSDKHook_OnTakeDamagePost[client])
@@ -202,21 +200,78 @@ stock void OnClientDisconnect_GunGame(int client)
 	delete g_GunGameData[client].rewardTimer;
 }
 
+public void EntWatch_OnPickUpItem(const char[] itemName, int client)
+{
+	if (!THIS_MODE_INFO.isOn)
+		return;
+		
+	ZR_SetClientWeaponRestrictAll(client, false);
+	CPrintToChat(client, "%s You have picked up an item, you can buy any weapon you want during gungame!", THIS_MODE_INFO.tag);
+}
+
+public void EntWatch_OnDropItem(const char[] itemName, int client)
+{
+	if (!THIS_MODE_INFO.isOn)
+		return;
+		
+	// restrict this player from buying all weapons
+	ZR_SetClientWeaponRestrictAll(client, true);
+		
+	// allow this player to buy the following weapons:
+	ZR_SetClientWeaponRestrict(client, "knife", false);
+	ZR_SetClientWeaponRestrict(client, "Projectile", false);
+	ZR_SetClientWeaponRestrict(client, "Equipment", false);
+	
+	if (IsPlayerAlive(client) && ZR_IsClientHuman(client))
+	{
+		int weaponType  = g_GunGameData[client].level[0];
+		int weaponIndex = g_GunGameData[client].level[1];
+	
+		GunGame_EquipWeapon(client, g_GunGameWeaponsList[weaponType][weaponIndex], true);
+	}
+}
+
 stock void ZR_OnClientInfected_GunGame(int client)
 {
 	#pragma unused client
+	if (!THIS_MODE_INFO.isOn)
+		return;
+		
+	if (!g_bMotherZombie)
+	{
+		// restrict players from buying all weapons
+		ZR_SetAllRestrictAll(true);
+		
+		// allow players to buy the following weapons:
+		ZR_SetAllWeaponRestrict("knife", false);
+		ZR_SetAllWeaponRestrict("Projectile", false);
+		ZR_SetAllWeaponRestrict("Equipment", false);
+		
+		for (int i = 1; i <= MaxClients; i++)
+		{
+			if (!IsClientInGame(i) || !IsPlayerAlive(i) || !ZR_IsClientHuman(i))
+				continue;
+			
+			if (EntWatch_HasSpecialItem(i))
+			{
+				ZR_SetClientWeaponRestrictAll(i, false);
+				continue;
+			}
+			
+			GunGame_ResetHuman(i);
+		}
+		
+		CPrintToChatAll("%s Your weapon will be upgraded when you reach the required damage for each weapon type!", THIS_MODE_INFO.tag);
+		CPrintToChatAll("%s Type {olive}!gungame {lightgreen}if you lost your weapons!", THIS_MODE_INFO.tag);
+	}
 }
 
 stock void Event_RoundStart_GunGame() {}
-stock void Event_RoundEnd_GunGame()
-{
-	for (int i = 1; i <= MaxClients; i++)
-		g_GunGameData[i].allowEquip = true;
-}
+stock void Event_RoundEnd_GunGame() {}
 
 stock void Event_PlayerSpawn_GunGame(int client)
 {
-	if (!THIS_MODE_INFO.isOn)
+	if (!THIS_MODE_INFO.isOn || !g_bMotherZombie)
 		return;
 		
 	CreateTimer(2.0, Timer_GunGame_CheckPlayerSpawn, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
@@ -228,13 +283,10 @@ Action Timer_GunGame_CheckPlayerSpawn(Handle timer, int userid)
 	if (!client)
 		return Plugin_Stop;
 		
-	GunGame_GiveReward(client, REWARD_NONE);
-	g_GunGameData[client].ResetLevel();
-	
 	if (!IsPlayerAlive(client) || !ZR_IsClientHuman(client))
 		return Plugin_Stop;
 		
-	GunGame_EquipWeapon(client, g_GunGameWeaponsList[0][GetRandomInt(0, 1)]);
+	GunGame_ResetHuman(client);
 	return Plugin_Stop;
 }
 
@@ -259,10 +311,19 @@ stock void OnTakeDamagePost_GunGame(int victim, int attacker, float damage)
 	if (!(1<=attacker<=MaxClients) || !IsPlayerAlive(attacker) || !IsPlayerAlive(victim) || !ZR_IsClientZombie(victim) || !ZR_IsClientHuman(attacker))
 		return;
 	
-	if (THIS_MODE_INFO.cvarInfo[GUNGAME_CONVAR_ENTWATCH].cvar.BoolValue && EntWatch_HasSpecialItem(attacker))
+	if (EntWatch_HasSpecialItem(attacker))
 		return;
 		
-	int neededDamage = THIS_MODE_INFO.cvarInfo[g_GunGameData[attacker].level[0]].cvar.IntValue;
+	char weapon[32];
+	GetClientWeapon(attacker, weapon, sizeof(weapon));
+	
+	int weaponType = g_GunGameData[attacker].level[0];
+	int weaponIndex = g_GunGameData[attacker].level[1];
+	
+	if (weaponType > 0 && strcmp(weapon, g_GunGameWeaponsList[weaponType][weaponIndex]) != 0)
+		return;
+		
+	int neededDamage = THIS_MODE_INFO.cvarInfo[weaponType].cvar.IntValue;
 	
 	if (g_GunGameData[attacker].dealtDamage >= neededDamage)
 	{
@@ -274,55 +335,78 @@ stock void OnTakeDamagePost_GunGame(int victim, int attacker, float damage)
 	g_GunGameData[attacker].dealtDamage += RoundToNearest(damage);
 }
 
-stock void OnWeaponEquip_GunGame(int client, int weapon, Action &result)
+stock void OnWeaponCanUse_GunGame(int client, int weapon, Action &result)
 {
 	if (!THIS_MODE_INFO.isOn)
 		return;
-	
-	if (!IsPlayerAlive(client) || ZR_IsClientZombie(client))
+		
+	if (!g_bMotherZombie)
 		return;
 	
-	if (THIS_MODE_INFO.cvarInfo[GUNGAME_CONVAR_ENTWATCH].cvar.BoolValue)
-	{
-	#if !defined _EntWatch_include
-		THIS_MODE_INFO.cvarInfo[GUNGAME_CONVAR_ENTWATCH].cvar.BoolValue = false;
+	if (ZR_IsClientZombie(client))
 		return;
-	#else
-		if (EntWatch_IsSpecialItem(weapon))
-			return;
-	#endif
-	}
+		
+	if (EntWatch_IsSpecialItem(weapon))
+		return;
 	
-	if (!g_GunGameData[client].allowEquip)
-	{
-		result = Plugin_Handled;
+	if (EntWatch_HasSpecialItem(client))
 		return;
-	}
+			
+	char weaponName[32];
+	GetEntityClassname(weapon, weaponName, sizeof(weaponName));
+
+	int weaponType = g_GunGameData[client].level[0];
+	int weaponIndex = g_GunGameData[client].level[1];
+	if (GunGame_CanUseWeapon(weaponType, weaponIndex, weaponName))
+		return;
+		
+	result = Plugin_Handled;
 }
 
-public Action CS_OnBuyCommand(int client, const char[] weapon)
+stock bool GunGame_CanUseWeapon(int weaponType, int weaponIndex, const char[] weaponName)
 {
-	if (!THIS_MODE_INFO.isOn)
-		return Plugin_Continue;
+	if (g_hGunGameWeaponsMap == null)
+	{
+		g_hGunGameWeaponsMap = new StringMap();
+		for (int i = 0; i < sizeof(g_GunGameWeaponsList); i++)
+		{
+			for (int j = 0; j < sizeof(g_GunGameWeaponsList[]); j++)
+			{
+				if (g_GunGameWeaponsList[i][j][0] == '\0')
+					continue;
+				
+				g_hGunGameWeaponsMap.SetValue(g_GunGameWeaponsList[i][j], i * sizeof(g_GunGameWeaponsList[]) + j);
+			}
+		}
+	}
+	
+	int thisVal;
+	if (!g_hGunGameWeaponsMap.GetValue(weaponName, thisVal))
+		return true;
+	
+	int curVal = weaponType * sizeof(g_GunGameWeaponsList[]) + weaponIndex;
+	if (THIS_MODE_INFO.cvarInfo[GUNGAME_CONVAR_CHANGE_WEAPON].cvar.BoolValue)
+		return (thisVal <= curVal);
+	
+	if (weaponType > 0 && thisVal <= 5)
+		return true;
+	
+	if (weaponType == 0 && thisVal <= 1)
+		return true;
 		
-	if (THIS_MODE_INFO.cvarInfo[GUNGAME_CONVAR_ENTWATCH].cvar.BoolValue)
-	{
-	#if !defined _EntWatch_include
-		THIS_MODE_INFO.cvarInfo[GUNGAME_CONVAR_ENTWATCH].cvar.BoolValue = false;
-		return Plugin_Continue;
-	#else
-		if (!EntWatch_HasSpecialItem(client))
-			return Plugin_Continue;
-	#endif
-	}
+	if (curVal == thisVal)
+		return true;
+		
+	return false;
+}
+
+stock void GunGame_ResetHuman(int client)
+{
+	GunGame_GiveReward(client, REWARD_NONE);
+	g_GunGameData[client].ResetLevel();
+	g_GunGameData[client].completedCycle = false;
 	
-	if (!g_GunGameData[client].allowEquip)
-	{
-		CPrintToChat(client, "%s You cannot buy/equip weapons during GunGame Escape Mode", THIS_MODE_INFO.tag);
-		return Plugin_Stop;
-	}
-	
-	return Plugin_Continue;
+	GunGame_EquipWeapon(client, g_GunGameWeaponsList[0][GetRandomInt(0, 1)]);
 }
 
 public Action Cmd_GunGameToggle(int client, int args)
@@ -338,8 +422,6 @@ public Action Cmd_GunGameToggle(int client, int args)
 	
 	CPrintToChatAll("%s GunGame Mode is now %s!", THIS_MODE_INFO.tag, THIS_MODE_INFO.isOn ? "On" : "Off");
 	
-	static bool cvarsValues[2];
-	
 	if (THIS_MODE_INFO.isOn)
 	{
 		FunModes_HookEvent(g_bEvent_RoundStart, "round_start", Event_RoundStart);
@@ -353,44 +435,15 @@ public Action Cmd_GunGameToggle(int client, int args)
 				continue;
 			
 			OnClientPutInServer_GunGame(i);
-			if (view_as<int>(g_GunGameData[i].reward) < view_as<int>(REWARD_HEGRENADES))
+			if (view_as<int>(g_GunGameData[i].reward) < view_as<int>(REWARD_SMOKEGRENADES))
 				GunGame_GiveReward(i, REWARD_NONE);
 		}
 		
-		CPrintToChatAll("%s Your weapon will be upgraded when you reach the required damage for each weapon type!", THIS_MODE_INFO.tag);
-		CS_TerminateRound(3.0, CSRoundEnd_Draw);
-		
-		ConVar cvar = FindConVar("zr_weapons_zmarket_rebuy");
-		if (cvar != null)
-		{
-			cvarsValues[0] = cvar.BoolValue;
-			cvar.BoolValue = false;
-			delete cvar;
-		}
-		
-		cvar = FindConVar("zr_weapons_zmarket");
-		if (cvar != null)
-		{
-			cvarsValues[1] = cvar.BoolValue;
-			cvar.BoolValue = false;
-			delete cvar;
-		}
+		FunModes_RestartRound();
 	}
 	else
 	{
-		ConVar cvar = FindConVar("zr_weapons_zmarket_rebuy");
-		if (cvar != null)
-		{
-			cvar.BoolValue = cvarsValues[0];
-			delete cvar;
-		}
-		
-		cvar = FindConVar("zr_weapons_zmarket");
-		if (cvar != null)
-		{
-			cvar.BoolValue = cvarsValues[1];
-			delete cvar;
-		}
+		ZR_SetAllRestrictAll(false);
 	}
 	
 	return Plugin_Handled;
@@ -405,8 +458,8 @@ public Action Cmd_GunGameSettings(int client, int args)
 	Menu menu = new Menu(Menu_GunGameSettings);
 
 	menu.SetTitle("%s - Settings", THIS_MODE_INFO.name);
-
-	menu.AddItem(NULL_STRING, "Show Cvars\n");
+	
+	menu.AddItem(NULL_STRING, "Show Cvars\n ");
 
 	menu.ExitBackButton = true;
 	menu.Display(client, MENU_TIME_FOREVER);
@@ -453,18 +506,13 @@ Action Cmd_GunGame(int client, int args)
 		return Plugin_Handled;
 	}
 	
-	if (THIS_MODE_INFO.cvarInfo[GUNGAME_CONVAR_ENTWATCH].cvar.BoolValue)
+	if (EntWatch_HasSpecialItem(client))
 	{
-	#if defined _EntWatch_include
-		if (EntWatch_HasSpecialItem(client))
-		{
-			static const char weapons[][] =  { "weapon_p90", "weapon_tmp", "weapon_ak47", "weapon_m4a1" };
-			GunGame_EquipWeapon(client, weapons[GetRandomInt(0, sizeof(weapons)-1)], true);
-			return Plugin_Handled;
-		}
-	#endif
+		static const char weapons[][] =  { "weapon_p90", "weapon_tmp", "weapon_ak47", "weapon_m4a1" };
+		GunGame_EquipWeapon(client, weapons[GetRandomInt(0, sizeof(weapons)-1)], true);
+		return Plugin_Handled;
 	}
-	
+
 	int weaponType = g_GunGameData[client].level[0];
 	int weaponIndex = g_GunGameData[client].level[1];
 	if (weaponType > 0)
@@ -473,8 +521,7 @@ Action Cmd_GunGame(int client, int args)
 			GunGame_EquipWeapon(client, g_GunGameWeaponsList[0][0], true);
 	}
 	
-	GunGame_EquipWeapon(client, g_GunGameWeaponsList[weaponType][weaponIndex], true);
-	
+	GunGame_EquipWeapon(client, g_GunGameWeaponsList[weaponType][weaponIndex], weaponType > 0);
 	return Plugin_Handled;
 }
 
@@ -483,14 +530,23 @@ void GunGame_GiveWeapon(int client)
 	int weaponType = g_GunGameData[client].level[0];
 	int weaponIndex = g_GunGameData[client].level[1];
 	
+	bool canUsePrevious = THIS_MODE_INFO.cvarInfo[GUNGAME_CONVAR_CHANGE_WEAPON].cvar.BoolValue;
+	if (canUsePrevious)
+	{
+		char thisWeapon[32];
+		strcopy(thisWeapon, sizeof(thisWeapon), g_GunGameWeaponsList[weaponType][weaponIndex]);
+		ReplaceString(thisWeapon, sizeof(thisWeapon), "weapon_", "");
+		ZR_SetClientWeaponRestrict(client, thisWeapon, false);
+	}
+	
 	/* If weapon type is still pistols */
 	if (weaponType == 0)
 	{
 		int secondary = GetPlayerWeaponSlot(client, CS_SLOT_SECONDARY);
 		if (!IsValidEntity(secondary))
 		{
-			GunGame_EquipWeapon(client, g_GunGameWeaponsList[0][0]);
 			g_GunGameData[client].level[0] = 0; g_GunGameData[client].level[1] = 0;
+			GunGame_EquipWeapon(client, g_GunGameWeaponsList[0][0]);
 			return;
 		}
 		
@@ -503,8 +559,8 @@ void GunGame_GiveWeapon(int client)
 		{
 			if (weaponIndex == 0)
 			{
-				GunGame_EquipWeapon(client, hasGlock ? "weapon_usp" : "weapon_glock");
 				g_GunGameData[client].level[1] = 1;
+				GunGame_EquipWeapon(client, hasGlock ? "weapon_usp" : "weapon_glock");
 				return;
 			}
 		}
@@ -528,24 +584,26 @@ void GunGame_GiveWeapon(int client)
 	g_GunGameData[client].level[0] = weaponType;
 	g_GunGameData[client].level[1] = weaponIndex;
 	
+	if (canUsePrevious)
+	{
+		char thisWeapon[32];
+		strcopy(thisWeapon, sizeof(thisWeapon), g_GunGameWeaponsList[weaponType][weaponIndex]);
+		ReplaceString(thisWeapon, sizeof(thisWeapon), "weapon_", "");
+		ZR_SetClientWeaponRestrict(client, thisWeapon, false);
+	}
+	
 	GunGame_EquipWeapon(client, g_GunGameWeaponsList[weaponType][weaponIndex], weaponType > 0);
 }
 
 void GunGame_EquipWeapon(int client, const char[] weaponName, bool keepSecondary = false)
 {
+	GunGame_StripPlayer(client, keepSecondary);
 	int weapon = GivePlayerItem(client, weaponName);
 	if (!IsValidEntity(weapon))
 		return;
 	
-	GunGame_StripPlayer(client, keepSecondary);
-	
-	g_GunGameData[client].allowEquip = true;
-	EquipPlayerWeapon(client, weapon);
-
 	if (g_hSwitchSDKCall != null)
 		SDKCall(g_hSwitchSDKCall, client, weapon, 0);
-
-	g_GunGameData[client].allowEquip = false;
 }
 
 void GunGame_StripPlayer(int client, bool keepSecondary = false, bool giveSecondary = false)
@@ -567,7 +625,7 @@ void GunGame_StripPlayer(int client, bool keepSecondary = false, bool giveSecond
 			continue;
 		}
 		
-		SDKHooks_DropWeapon(client, wp);
+		RemovePlayerItem(client, wp);
 		RemoveEntity(wp);
 	}
 }
@@ -580,8 +638,7 @@ void GunGame_ShowRewardsMenu(int client)
 	menu.SetTitle("[GunGame Escape] You have completed a gungame cycle! Choose your reward!\nYou only have 60s to switch your rewards");
 	
 	menu.AddItem("0", "More Speed", g_GunGameData[client].reward == REWARD_SPEED ? ITEMDRAW_DISABLED : ITEMDRAW_DEFAULT);
-	menu.AddItem("1", "Lower Gravity", g_GunGameData[client].reward == REWARD_GRAVITY ? ITEMDRAW_DISABLED : ITEMDRAW_DEFAULT);
-	menu.AddItem("2", "More hegrenades", g_GunGameData[client].reward == REWARD_HEGRENADES ? ITEMDRAW_DISABLED : ITEMDRAW_DEFAULT);
+	menu.AddItem("2", "Smokegrenades (Freeze)", g_GunGameData[client].reward == REWARD_SMOKEGRENADES ? ITEMDRAW_DISABLED : ITEMDRAW_DEFAULT);
 	
 	menu.ExitBackButton = true;
 	menu.Display(client, 60);
@@ -596,6 +653,12 @@ int Menu_GunGame_ShowRewards(Menu menu, MenuAction action, int param1, int param
 		
 		case MenuAction_Select:
 		{
+			if (!g_GunGameData[param1].completedCycle)
+			{
+				CPrintToChat(param1, "%s You cannot pick a reward right now, Sorry :p", THIS_MODE_INFO.tag);
+				return 0;
+			}
+			
 			char data[3];
 			menu.GetItem(param2, data, sizeof(data));
 			
@@ -618,13 +681,6 @@ void GunGame_GiveReward(int client, GunGame_Reward reward)
 	{
 		case REWARD_SPEED:
 		{
-			/* Reset Gravity */
-			if (g_GunGameData[client].originalGravity != 0.0)
-			{
-				SetEntityGravity(client, g_GunGameData[client].originalGravity);
-				g_GunGameData[client].originalGravity = 0.0;
-			}
-			
 			if (!IsPlayerAlive(client) || !ZR_IsClientHuman(client))
 				return;
 				
@@ -637,7 +693,7 @@ void GunGame_GiveReward(int client, GunGame_Reward reward)
 			g_GunGameData[client].rewardTimer = CreateTimer(THIS_MODE_INFO.cvarInfo[GUNGAME_CONVAR_REWARD_SPEED].cvar.FloatValue, Timer_GunGameReward, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
 		}
 		
-		case REWARD_GRAVITY:
+		case REWARD_SMOKEGRENADES:
 		{
 			/* Reset Speed */
 			if (g_GunGameData[client].originalSpeed != 0.0)
@@ -649,52 +705,16 @@ void GunGame_GiveReward(int client, GunGame_Reward reward)
 			if (!IsPlayerAlive(client) || !ZR_IsClientHuman(client))
 				return;
 				
-			g_GunGameData[client].originalGravity = GetEntityGravity(client);
-			SetEntityGravity(client, 0.5);
+			int smoke = GivePlayerItem(client, "weapon_smokegrenade");
+			EquipPlayerWeapon(client, smoke);
+			int count = THIS_MODE_INFO.cvarInfo[GUNGAME_CONVAR_SMOKEGRENADES_COUNT].cvar.IntValue;
+			SET_GRENADES_COUNT(client, SMOKEGRENADE, GET_GRENADES_COUNT(client, SMOKEGRENADE)+count-1);
 			
-			CPrintToChat(client, "%s You have been granted a lower gravity for finishing a gungame cycle!", THIS_MODE_INFO.tag);
-			
-			delete g_GunGameData[client].rewardTimer;
-			g_GunGameData[client].rewardTimer = CreateTimer(THIS_MODE_INFO.cvarInfo[GUNGAME_CONVAR_REWARD_GRAVITY].cvar.FloatValue, Timer_GunGameReward, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
-		}
-		
-		case REWARD_HEGRENADES:
-		{
-			/* Reset Gravity */
-			if (g_GunGameData[client].originalGravity != 0.0)
-			{
-				SetEntityGravity(client, g_GunGameData[client].originalGravity);
-				g_GunGameData[client].originalGravity = 0.0;
-			}
-			
-			/* Reset Speed */
-			if (g_GunGameData[client].originalSpeed != 0.0)
-			{
-				SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", g_GunGameData[client].originalSpeed);
-				g_GunGameData[client].originalSpeed = 0.0;
-			}
-			
-			if (!IsPlayerAlive(client) || !ZR_IsClientHuman(client))
-				return;
-				
-			g_GunGameData[client].allowEquip = true;
-			GivePlayerItem(client, "weapon_hegrenade");
-			int count = THIS_MODE_INFO.cvarInfo[GUNGAME_CONVAR_HEGRENADES_COUNT].cvar.IntValue;
-			GiveGrenadesToClient(client, GrenadeType_HEGrenade, count-1);
-			g_GunGameData[client].allowEquip = false;
-			
-			CPrintToChat(client, "%s You have been granted {olive}%d extra hegrenades {lightgreen}for finishing a gungame cycle!", THIS_MODE_INFO.tag, count);
+			CPrintToChat(client, "%s You have been granted {olive}%d extra SMOKEGRENADES {lightgreen}for finishing a gungame cycle!", THIS_MODE_INFO.tag, count);
 		}
 		
 		default:
-		{	
-			/* Reset Gravity */
-			if (g_GunGameData[client].originalGravity != 0.0)
-			{
-				SetEntityGravity(client, g_GunGameData[client].originalGravity);
-				g_GunGameData[client].originalGravity = 0.0;
-			}
-				
+		{		
 			/* Reset Speed */
 			if (g_GunGameData[client].originalSpeed != 0.0)
 			{

--- a/addons/sourcemod/scripting/Fun_Modes/GunGame.sp
+++ b/addons/sourcemod/scripting/Fun_Modes/GunGame.sp
@@ -79,6 +79,9 @@ GunGame_Data g_GunGameData[MAXPLAYERS + 1];
 
 StringMap g_hGunGameWeaponsMap;
 
+ConVar g_cvZRRestrictPerPlayer;
+bool g_bZRRestrictPerPlayer;
+
 stock void OnPluginStart_GunGame()
 {
 	THIS_MODE_INFO.name = "GunGame";
@@ -160,6 +163,12 @@ stock void OnPluginStart_GunGame()
 	THIS_MODE_INFO.cvarInfo[GUNGAME_CONVAR_TOGGLE].cvar.AddChangeHook(OnGunGameModeToggle);
 }
 
+/* TODO: Move this to FunModes.sp */
+public void OnAllPluginsLoaded()
+{
+	g_cvZRRestrictPerPlayer = FindConVar("zr_weapons_restrict_perplayer");
+}
+
 void OnGunGameModeToggle(ConVar cvar, const char[] newValue, const char[] oldValue)
 {
 	if (THIS_MODE_INFO.isOn)
@@ -173,6 +182,11 @@ stock void OnMapEnd_GunGame()
 	
 	for (int i = 1; i <= MaxClients; i++)
 		g_GunGameData[i].rewardTimer = null;
+	
+	if (g_cvZRRestrictPerPlayer == null)
+		return;
+	
+	g_cvZRRestrictPerPlayer.BoolValue = g_bZRRestrictPerPlayer;
 }
 
 stock void OnClientPutInServer_GunGame(int client)
@@ -417,6 +431,12 @@ public Action Cmd_GunGameToggle(int client, int args)
 		return Plugin_Handled;
 	}
 
+	if (g_cvZRRestrictPerPlayer == null)
+	{
+		CReplyToCommand(client, "%s A convar dependecy is missing, cannot toggle this mode without it", THIS_MODE_INFO.tag);
+		return Plugin_Handled;
+	}
+
 	/* You can change whatever you want here */
 	CHANGE_MODE_INFO(THIS_MODE_INFO, isOn, !THIS_MODE_INFO.isOn, THIS_MODE_INFO.index);
 	
@@ -440,10 +460,14 @@ public Action Cmd_GunGameToggle(int client, int args)
 		}
 		
 		FunModes_RestartRound();
+
+		g_bZRRestrictPerPlayer = g_cvZRRestrictPerPlayer.BoolValue;
+		g_cvZRRestrictPerPlayer.BoolValue = true;
 	}
 	else
 	{
 		ZR_SetAllRestrictAll(false);
+		g_cvZRRestrictPerPlayer.BoolValue = g_bZRRestrictPerPlayer;
 	}
 	
 	return Plugin_Handled;

--- a/addons/sourcemod/scripting/Fun_Modes/GunGame.sp
+++ b/addons/sourcemod/scripting/Fun_Modes/GunGame.sp
@@ -33,10 +33,8 @@ ModeInfo g_GunGameInfo;
 #define GUNGAME_CONVAR_RIFLES_DAMAGE		3
 #define GUNGAME_CONVAR_M249_DAMAGE			4
 #define GUNGAME_CONVAR_SMOKEGRENADES_COUNT 	5
-#define GUNGAME_CONVAR_REWARD_GRAVITY		6
-#define GUNGAME_CONVAR_REWARD_SPEED			7
-#define GUNGAME_CONVAR_CHANGE_WEAPON		8
-#define GUNGAME_CONVAR_TOGGLE 				9
+#define GUNGAME_CONVAR_REWARD_SPEED			6
+#define GUNGAME_CONVAR_TOGGLE 				7
 
 static const char g_GunGameWeaponsList[][][] =
 {
@@ -60,27 +58,21 @@ enum struct GunGame_Data
 	int dealtDamage;
 	
 	bool completedCycle;
+	bool allowEquip;
 	
 	float originalSpeed;
-	float originalGravity;
 	
 	GunGame_Reward reward;
 	Handle rewardTimer;
 	
 	void ResetLevel()
 	{
-		this.dealtDamage = 0;
 		this.level[0] = 0;
 		this.level[1] = 0;
 	}
 }
 
 GunGame_Data g_GunGameData[MAXPLAYERS + 1];
-
-StringMap g_hGunGameWeaponsMap;
-
-ConVar g_cvZRRestrictPerPlayer;
-bool g_bZRRestrictPerPlayer;
 
 stock void OnPluginStart_GunGame()
 {
@@ -91,62 +83,50 @@ stock void OnPluginStart_GunGame()
 	/* THESE ARE THE STANDARD COMMANDS THAT ALL MODES SHOULD HAVE */
 	RegAdminCmd("sm_fm_gungame", Cmd_GunGameToggle, ADMFLAG_CONVARS, "Turn GunGame Mode On/Off");
 	RegAdminCmd("sm_gungame_settings", Cmd_GunGameSettings, ADMFLAG_CONVARS, "Open GunGame Sttings Menu");
-
+	
 	RegConsoleCmd("sm_gungame", Cmd_GunGame, "Get your original weapons");
 
 	/* CONVARS */
 	DECLARE_FM_CVAR(
 		THIS_MODE_INFO.cvarInfo, GUNGAME_CONVAR_PISTOLS_DAMAGE,
-		"sm_gungame_pistols_damage", "400", "The required damage needed for pistols to upgrade",
+		"sm_gungame_pistols_damage", "1200", "The required damage needed for pistols to upgrade",
 		("800,1000,1500,2000,2500"), "int"
 	);
 	
 	DECLARE_FM_CVAR(
 		THIS_MODE_INFO.cvarInfo, GUNGAME_CONVAR_SHOTGUNS_DAMAGE,
-		"sm_gungame_shotguns_damage", "900", "The required damage needed for shotguns to upgrade",
+		"sm_gungame_shotguns_damage", "2200", "The required damage needed for shotguns to upgrade",
 		("800,1000,1500,2000,2500"), "int"
 	);
 	
 	DECLARE_FM_CVAR(
 		THIS_MODE_INFO.cvarInfo, GUNGAME_CONVAR_SMGS_DAMAGE,
-		"sm_gungame_smgs_damage", "1800", "The required damage needed for smgs to upgrade",
+		"sm_gungame_smgs_damage", "4200", "The required damage needed for smgs to upgrade",
 		("800,1000,1500,2000,2500"), "int"
 	);
 	
 	DECLARE_FM_CVAR(
 		THIS_MODE_INFO.cvarInfo, GUNGAME_CONVAR_RIFLES_DAMAGE,
-		"sm_gungame_rifles_damage", "2400", "The required damage needed for rifles to upgrade",
+		"sm_gungame_rifles_damage", "3800", "The required damage needed for rifles to upgrade",
 		("800,1000,1500,2000,2500"), "int"
 	);
 	
 	DECLARE_FM_CVAR(
 		THIS_MODE_INFO.cvarInfo, GUNGAME_CONVAR_M249_DAMAGE,
-		"sm_gungame_m249_damage", "4000", "The required damage needed for m249 to finish the gungame cycle",
+		"sm_gungame_m249_damage", "8000", "The required damage needed for m249 to finish the gungame cycle",
 		("800,1000,1500,2000,2500"), "int"
 	);
 	
 	DECLARE_FM_CVAR(
 		THIS_MODE_INFO.cvarInfo, GUNGAME_CONVAR_SMOKEGRENADES_COUNT,
-		"sm_gungame_smokegrenades_reward", "2", "How many smokegrenades to give to the player when completing a cycle",
+		"sm_gungame_hegrenades_reward", "2", "How many smokegrenades to give to the player when completing a cycle",
 		("1,3,5,10,15"), "int"
-	);
-	
-	DECLARE_FM_CVAR(
-		THIS_MODE_INFO.cvarInfo, GUNGAME_CONVAR_REWARD_GRAVITY,
-		"sm_gungame_gravity_reward", "100.0", "How many seconds can the player keep their low gravity hold",
-		("20.0,30.0,40.0,60.0,80.0,100.0"), "float"
 	);
 	
 	DECLARE_FM_CVAR(
 		THIS_MODE_INFO.cvarInfo, GUNGAME_CONVAR_REWARD_SPEED,
 		"sm_gungame_speed_reward", "100.0", "How many seconds can the player keep their high speed hold",
 		("20.0,30.0,40.0,60.0,80.0,100.0"), "float"
-	);
-	
-	DECLARE_FM_CVAR(
-		THIS_MODE_INFO.cvarInfo, GUNGAME_CONVAR_CHANGE_WEAPON,
-		"sm_gungame_allow_change_weapon", "0", "Enable/Disable allowing players to change their weapon to lower level",
-		("0,1"), "bool"
 	);
 	
 	DECLARE_FM_CVAR(
@@ -163,12 +143,6 @@ stock void OnPluginStart_GunGame()
 	THIS_MODE_INFO.cvarInfo[GUNGAME_CONVAR_TOGGLE].cvar.AddChangeHook(OnGunGameModeToggle);
 }
 
-/* TODO: Move this to FunModes.sp */
-public void OnAllPluginsLoaded()
-{
-	g_cvZRRestrictPerPlayer = FindConVar("zr_weapons_restrict_perplayer");
-}
-
 void OnGunGameModeToggle(ConVar cvar, const char[] newValue, const char[] oldValue)
 {
 	if (THIS_MODE_INFO.isOn)
@@ -182,11 +156,6 @@ stock void OnMapEnd_GunGame()
 	
 	for (int i = 1; i <= MaxClients; i++)
 		g_GunGameData[i].rewardTimer = null;
-	
-	if (g_cvZRRestrictPerPlayer == null)
-		return;
-	
-	g_cvZRRestrictPerPlayer.BoolValue = g_bZRRestrictPerPlayer;
 }
 
 stock void OnClientPutInServer_GunGame(int client)
@@ -194,12 +163,13 @@ stock void OnClientPutInServer_GunGame(int client)
 	if (!THIS_MODE_INFO.isOn)
 		return;
 	
+	g_GunGameData[client].allowEquip = true;
 	g_GunGameData[client].ResetLevel();
 	
-	if (!g_bSDKHook_WeaponCanUse[client])
+	if (!g_bSDKHook_WeaponEquip[client])
 	{
-		SDKHook(client, SDKHook_WeaponCanUse, OnWeaponCanUse);
-		g_bSDKHook_WeaponCanUse[client] = true;
+		SDKHook(client, SDKHook_WeaponEquip, OnWeaponEquip);
+		g_bSDKHook_WeaponEquip[client] = true;
 	}
 	
 	if (!g_bSDKHook_OnTakeDamagePost[client])
@@ -212,37 +182,6 @@ stock void OnClientPutInServer_GunGame(int client)
 stock void OnClientDisconnect_GunGame(int client)
 {
 	delete g_GunGameData[client].rewardTimer;
-}
-
-public void EntWatch_OnPickUpItem(const char[] itemName, int client)
-{
-	if (!THIS_MODE_INFO.isOn)
-		return;
-		
-	ZR_SetClientWeaponRestrictAll(client, false);
-	CPrintToChat(client, "%s You have picked up an item, you can buy any weapon you want during gungame!", THIS_MODE_INFO.tag);
-}
-
-public void EntWatch_OnDropItem(const char[] itemName, int client)
-{
-	if (!THIS_MODE_INFO.isOn)
-		return;
-		
-	// restrict this player from buying all weapons
-	ZR_SetClientWeaponRestrictAll(client, true);
-		
-	// allow this player to buy the following weapons:
-	ZR_SetClientWeaponRestrict(client, "knife", false);
-	ZR_SetClientWeaponRestrict(client, "Projectile", false);
-	ZR_SetClientWeaponRestrict(client, "Equipment", false);
-	
-	if (IsPlayerAlive(client) && ZR_IsClientHuman(client))
-	{
-		int weaponType  = g_GunGameData[client].level[0];
-		int weaponIndex = g_GunGameData[client].level[1];
-	
-		GunGame_EquipWeapon(client, g_GunGameWeaponsList[weaponType][weaponIndex], true);
-	}
 }
 
 stock void ZR_OnClientInfected_GunGame(int client)
@@ -267,21 +206,22 @@ stock void ZR_OnClientInfected_GunGame(int client)
 				continue;
 			
 			if (EntWatch_HasSpecialItem(i))
-			{
-				ZR_SetClientWeaponRestrictAll(i, false);
 				continue;
-			}
-			
+
 			GunGame_ResetHuman(i);
 		}
-		
+
 		CPrintToChatAll("%s Your weapon will be upgraded when you reach the required damage for each weapon type!", THIS_MODE_INFO.tag);
 		CPrintToChatAll("%s Type {olive}!gungame {lightgreen}if you lost your weapons!", THIS_MODE_INFO.tag);
 	}
 }
 
 stock void Event_RoundStart_GunGame() {}
-stock void Event_RoundEnd_GunGame() {}
+stock void Event_RoundEnd_GunGame()
+{
+	for (int i = 1; i <= MaxClients; i++)
+		g_GunGameData[i].allowEquip = true;
+}
 
 stock void Event_PlayerSpawn_GunGame(int client)
 {
@@ -328,16 +268,7 @@ stock void OnTakeDamagePost_GunGame(int victim, int attacker, float damage)
 	if (EntWatch_HasSpecialItem(attacker))
 		return;
 		
-	char weapon[32];
-	GetClientWeapon(attacker, weapon, sizeof(weapon));
-	
-	int weaponType = g_GunGameData[attacker].level[0];
-	int weaponIndex = g_GunGameData[attacker].level[1];
-	
-	if (weaponType > 0 && strcmp(weapon, g_GunGameWeaponsList[weaponType][weaponIndex]) != 0)
-		return;
-		
-	int neededDamage = THIS_MODE_INFO.cvarInfo[weaponType].cvar.IntValue;
+	int neededDamage = THIS_MODE_INFO.cvarInfo[g_GunGameData[attacker].level[0]].cvar.IntValue;
 	
 	if (g_GunGameData[attacker].dealtDamage >= neededDamage)
 	{
@@ -349,69 +280,50 @@ stock void OnTakeDamagePost_GunGame(int victim, int attacker, float damage)
 	g_GunGameData[attacker].dealtDamage += RoundToNearest(damage);
 }
 
-stock void OnWeaponCanUse_GunGame(int client, int weapon, Action &result)
+stock void OnWeaponEquip_GunGame(int client, int weapon, Action &result)
 {
 	if (!THIS_MODE_INFO.isOn)
 		return;
-		
-	if (!g_bMotherZombie)
+	
+	if (!IsPlayerAlive(client) || ZR_IsClientZombie(client))
 		return;
 	
-	if (ZR_IsClientZombie(client))
+	char className[32];
+	GetEntityClassname(weapon, className, sizeof(className));
+
+	// kevlar, hegrenades and smokegrenades:
+	if (StrContains(className, "item_", false) != -1 || StrContains(className, "grenade", false) != -1)
 		return;
-		
+	
+	// flashbang
+	if (className[7] == 'f' && className[8] == 'l')
+		return;
+
 	if (EntWatch_IsSpecialItem(weapon))
 		return;
-	
-	if (EntWatch_HasSpecialItem(client))
-		return;
-			
-	char weaponName[32];
-	GetEntityClassname(weapon, weaponName, sizeof(weaponName));
 
-	int weaponType = g_GunGameData[client].level[0];
-	int weaponIndex = g_GunGameData[client].level[1];
-	if (GunGame_CanUseWeapon(weaponType, weaponIndex, weaponName))
+	if (!g_GunGameData[client].allowEquip)
+	{
+		result = Plugin_Handled;
 		return;
-		
-	result = Plugin_Handled;
+	}
 }
 
-stock bool GunGame_CanUseWeapon(int weaponType, int weaponIndex, const char[] weaponName)
+public Action CS_OnBuyCommand(int client, const char[] weapon)
 {
-	if (g_hGunGameWeaponsMap == null)
+	if (!THIS_MODE_INFO.isOn)
+		return Plugin_Continue;
+		
+	if (EntWatch_HasSpecialItem(client))
+		return Plugin_Continue;
+
+	if (!g_GunGameData[client].allowEquip)
 	{
-		g_hGunGameWeaponsMap = new StringMap();
-		for (int i = 0; i < sizeof(g_GunGameWeaponsList); i++)
-		{
-			for (int j = 0; j < sizeof(g_GunGameWeaponsList[]); j++)
-			{
-				if (g_GunGameWeaponsList[i][j][0] == '\0')
-					continue;
-				
-				g_hGunGameWeaponsMap.SetValue(g_GunGameWeaponsList[i][j], i * sizeof(g_GunGameWeaponsList[]) + j);
-			}
-		}
+		CPrintToChat(client, "%s You cannot buy/equip weapons during GunGame Escape Mode", THIS_MODE_INFO.tag);
+		return Plugin_Stop;
 	}
 	
-	int thisVal;
-	if (!g_hGunGameWeaponsMap.GetValue(weaponName, thisVal))
-		return true;
-	
-	int curVal = weaponType * sizeof(g_GunGameWeaponsList[]) + weaponIndex;
-	if (THIS_MODE_INFO.cvarInfo[GUNGAME_CONVAR_CHANGE_WEAPON].cvar.BoolValue)
-		return (thisVal <= curVal);
-	
-	if (weaponType > 0 && thisVal <= 5)
-		return true;
-	
-	if (weaponType == 0 && thisVal <= 1)
-		return true;
-		
-	if (curVal == thisVal)
-		return true;
-		
-	return false;
+	return Plugin_Continue;
 }
 
 stock void GunGame_ResetHuman(int client)
@@ -431,16 +343,12 @@ public Action Cmd_GunGameToggle(int client, int args)
 		return Plugin_Handled;
 	}
 
-	if (g_cvZRRestrictPerPlayer == null)
-	{
-		CReplyToCommand(client, "%s A convar dependecy is missing, cannot toggle this mode without it", THIS_MODE_INFO.tag);
-		return Plugin_Handled;
-	}
-
 	/* You can change whatever you want here */
 	CHANGE_MODE_INFO(THIS_MODE_INFO, isOn, !THIS_MODE_INFO.isOn, THIS_MODE_INFO.index);
 	
 	CPrintToChatAll("%s GunGame Mode is now %s!", THIS_MODE_INFO.tag, THIS_MODE_INFO.isOn ? "On" : "Off");
+	
+	static bool cvarsValues[2];
 	
 	if (THIS_MODE_INFO.isOn)
 	{
@@ -461,13 +369,37 @@ public Action Cmd_GunGameToggle(int client, int args)
 		
 		FunModes_RestartRound();
 
-		g_bZRRestrictPerPlayer = g_cvZRRestrictPerPlayer.BoolValue;
-		g_cvZRRestrictPerPlayer.BoolValue = true;
+		ConVar cvar = FindConVar("zr_weapons_zmarket_rebuy");
+		if (cvar != null)
+		{
+			cvarsValues[0] = cvar.BoolValue;
+			cvar.BoolValue = false;
+			delete cvar;
+		}
+		
+		cvar = FindConVar("zr_weapons_zmarket");
+		if (cvar != null)
+		{
+			cvarsValues[1] = cvar.BoolValue;
+			cvar.BoolValue = false;
+			delete cvar;
+		}
 	}
 	else
 	{
-		ZR_SetAllRestrictAll(false);
-		g_cvZRRestrictPerPlayer.BoolValue = g_bZRRestrictPerPlayer;
+		ConVar cvar = FindConVar("zr_weapons_zmarket_rebuy");
+		if (cvar != null)
+		{
+			cvar.BoolValue = cvarsValues[0];
+			delete cvar;
+		}
+		
+		cvar = FindConVar("zr_weapons_zmarket");
+		if (cvar != null)
+		{
+			cvar.BoolValue = cvarsValues[1];
+			delete cvar;
+		}
 	}
 	
 	return Plugin_Handled;
@@ -482,8 +414,8 @@ public Action Cmd_GunGameSettings(int client, int args)
 	Menu menu = new Menu(Menu_GunGameSettings);
 
 	menu.SetTitle("%s - Settings", THIS_MODE_INFO.name);
-	
-	menu.AddItem(NULL_STRING, "Show Cvars\n ");
+
+	menu.AddItem(NULL_STRING, "Show Cvars\n");
 
 	menu.ExitBackButton = true;
 	menu.Display(client, MENU_TIME_FOREVER);
@@ -545,7 +477,8 @@ Action Cmd_GunGame(int client, int args)
 			GunGame_EquipWeapon(client, g_GunGameWeaponsList[0][0], true);
 	}
 	
-	GunGame_EquipWeapon(client, g_GunGameWeaponsList[weaponType][weaponIndex], weaponType > 0);
+	GunGame_EquipWeapon(client, g_GunGameWeaponsList[weaponType][weaponIndex], true);
+	
 	return Plugin_Handled;
 }
 
@@ -554,23 +487,14 @@ void GunGame_GiveWeapon(int client)
 	int weaponType = g_GunGameData[client].level[0];
 	int weaponIndex = g_GunGameData[client].level[1];
 	
-	bool canUsePrevious = THIS_MODE_INFO.cvarInfo[GUNGAME_CONVAR_CHANGE_WEAPON].cvar.BoolValue;
-	if (canUsePrevious)
-	{
-		char thisWeapon[32];
-		strcopy(thisWeapon, sizeof(thisWeapon), g_GunGameWeaponsList[weaponType][weaponIndex]);
-		ReplaceString(thisWeapon, sizeof(thisWeapon), "weapon_", "");
-		ZR_SetClientWeaponRestrict(client, thisWeapon, false);
-	}
-	
 	/* If weapon type is still pistols */
 	if (weaponType == 0)
 	{
 		int secondary = GetPlayerWeaponSlot(client, CS_SLOT_SECONDARY);
 		if (!IsValidEntity(secondary))
 		{
-			g_GunGameData[client].level[0] = 0; g_GunGameData[client].level[1] = 0;
 			GunGame_EquipWeapon(client, g_GunGameWeaponsList[0][0]);
+			g_GunGameData[client].level[0] = 0; g_GunGameData[client].level[1] = 0;
 			return;
 		}
 		
@@ -583,8 +507,8 @@ void GunGame_GiveWeapon(int client)
 		{
 			if (weaponIndex == 0)
 			{
-				g_GunGameData[client].level[1] = 1;
 				GunGame_EquipWeapon(client, hasGlock ? "weapon_usp" : "weapon_glock");
+				g_GunGameData[client].level[1] = 1;
 				return;
 			}
 		}
@@ -608,33 +532,31 @@ void GunGame_GiveWeapon(int client)
 	g_GunGameData[client].level[0] = weaponType;
 	g_GunGameData[client].level[1] = weaponIndex;
 	
-	if (canUsePrevious)
-	{
-		char thisWeapon[32];
-		strcopy(thisWeapon, sizeof(thisWeapon), g_GunGameWeaponsList[weaponType][weaponIndex]);
-		ReplaceString(thisWeapon, sizeof(thisWeapon), "weapon_", "");
-		ZR_SetClientWeaponRestrict(client, thisWeapon, false);
-	}
-	
 	GunGame_EquipWeapon(client, g_GunGameWeaponsList[weaponType][weaponIndex], weaponType > 0);
 }
 
 void GunGame_EquipWeapon(int client, const char[] weaponName, bool keepSecondary = false)
 {
-	GunGame_StripPlayer(client, keepSecondary);
 	int weapon = GivePlayerItem(client, weaponName);
 	if (!IsValidEntity(weapon))
 		return;
 	
+	GunGame_StripPlayer(client, keepSecondary);
+	
+	g_GunGameData[client].allowEquip = true;
+	EquipPlayerWeapon(client, weapon);
+
 	if (g_hSwitchSDKCall != null)
 		SDKCall(g_hSwitchSDKCall, client, weapon, 0);
+
+	g_GunGameData[client].allowEquip = false;
 }
 
 void GunGame_StripPlayer(int client, bool keepSecondary = false, bool giveSecondary = false)
 {
 	for (int i = 0; i <= 5; i++)
 	{
-		if (i == CS_SLOT_KNIFE || i == CS_SLOT_GRENADE)
+		if (i != CS_SLOT_SECONDARY && i != CS_SLOT_PRIMARY)
 			continue;
 			
 		if (keepSecondary && i == CS_SLOT_SECONDARY)
@@ -649,7 +571,7 @@ void GunGame_StripPlayer(int client, bool keepSecondary = false, bool giveSecond
 			continue;
 		}
 		
-		RemovePlayerItem(client, wp);
+		SDKHooks_DropWeapon(client, wp);
 		RemoveEntity(wp);
 	}
 }

--- a/addons/sourcemod/scripting/Fun_Modes/GunGame.sp
+++ b/addons/sourcemod/scripting/Fun_Modes/GunGame.sp
@@ -192,14 +192,6 @@ stock void ZR_OnClientInfected_GunGame(int client)
 		
 	if (!g_bMotherZombie)
 	{
-		// restrict players from buying all weapons
-		ZR_SetAllRestrictAll(true);
-		
-		// allow players to buy the following weapons:
-		ZR_SetAllWeaponRestrict("knife", false);
-		ZR_SetAllWeaponRestrict("Projectile", false);
-		ZR_SetAllWeaponRestrict("Equipment", false);
-		
 		for (int i = 1; i <= MaxClients; i++)
 		{
 			if (!IsClientInGame(i) || !IsPlayerAlive(i) || !ZR_IsClientHuman(i))

--- a/addons/sourcemod/scripting/Fun_Modes/HealBeacon.sp
+++ b/addons/sourcemod/scripting/Fun_Modes/HealBeacon.sp
@@ -695,6 +695,8 @@ public Action Cmd_HealBeaconToggle(int client, int args)
 			ReplyToCommand(client, "%s HealBeacon Mode is now ON!", THIS_MODE_INFO.tag);
 		else
 			CReplyToCommand(client, "%s %T", THIS_MODE_INFO.tag, "HealBeacon_Enabled", client);
+			
+		FunModes_RestartRound();
 	}
 
 	CHANGE_MODE_INFO(THIS_MODE_INFO, isOn, !THIS_MODE_INFO.isOn, THIS_MODE_INFO.index);

--- a/addons/sourcemod/scripting/Fun_Modes/PullGame.sp
+++ b/addons/sourcemod/scripting/Fun_Modes/PullGame.sp
@@ -181,7 +181,7 @@ public Action Cmd_PullGameToggle(int client, int args)
 		
 		CPrintToChatAll("%s {olive}%d Random Humans {lightgreen}and {olive}%d Random Zombies {lightgreen}will be selected for the pullgame every %d seconds", THIS_MODE_INFO.tag, humansCount, zombiesCount, interval);
 		
-		CS_TerminateRound(3.0, CSRoundEnd_Draw);
+		FunModes_RestartRound();
 	}
 	else
 		PullGame_ToggleTimer(false);

--- a/addons/sourcemod/scripting/Fun_Modes/RealityShift.sp
+++ b/addons/sourcemod/scripting/Fun_Modes/RealityShift.sp
@@ -162,7 +162,7 @@ public Action Cmd_RealityShiftToggle(int client, int args)
 		int interval = THIS_MODE_INFO.cvarInfo[REALITYSHIFT_CONVAR_TIMER_INTERVAL].cvar.IntValue;
 		CPrintToChatAll("%s Positions will be swapped every {olive}%d seconds!", THIS_MODE_INFO.tag, interval);
 		
-		CS_TerminateRound(3.0, CSRoundEnd_Draw);
+		FunModes_RestartRound();
 	}
 	else
 		delete g_hRealityShiftTimer;

--- a/addons/sourcemod/scripting/Fun_Modes/RedLightGreenLight.sp
+++ b/addons/sourcemod/scripting/Fun_Modes/RedLightGreenLight.sp
@@ -35,7 +35,8 @@ stock void OnPluginStart_RLGL()
 
 	/* ADMIN COMMANDS */
 	RegAdminCmd("sm_fm_rlgl", Cmd_RLGLToggle, ADMFLAG_CONVARS, "Enable/Disable RedLightGreenLight mode.");
-
+	RegAdminCmd("sm_rlgl_settings", Cmd_RLGLSettings, ADMFLAG_CONVARS, "Open RLGL Settings Menu");
+	
 	/* CONVARS */
 	DECLARE_FM_CVAR(
 		THIS_MODE_INFO.cvarInfo, RLGL_CONVAR_TIME_BETWEEN_DAMAGE, 

--- a/addons/sourcemod/scripting/Fun_Modes/VIPMode.sp
+++ b/addons/sourcemod/scripting/Fun_Modes/VIPMode.sp
@@ -232,7 +232,7 @@ stock void OnTakeDamage_VIPMode(int victim, int attacker, float damage, Action &
 		g_bDiedFromLaser[victim] = true;
 }
 
-stock void OnWeaponEquip_VIPMode(int client, int weapon, Action &result)
+stock void OnWeaponCanUse_VIPMode(int client, int weapon, Action &result)
 {
 	#pragma unused client
 	#pragma unused weapon

--- a/addons/sourcemod/scripting/Fun_Modes/VIPMode.sp
+++ b/addons/sourcemod/scripting/Fun_Modes/VIPMode.sp
@@ -232,7 +232,7 @@ stock void OnTakeDamage_VIPMode(int victim, int attacker, float damage, Action &
 		g_bDiedFromLaser[victim] = true;
 }
 
-stock void OnWeaponCanUse_VIPMode(int client, int weapon, Action &result)
+stock void OnWeaponEquip_VIPMode(int client, int weapon, Action &result)
 {
 	#pragma unused client
 	#pragma unused weapon


### PR DESCRIPTION
- **BlindMode:** Make blind automatically fade in instead of out
- **ChaosWeapons**: Add a countdown before changing the weapon and also ability to buy the weapon by press F
- **CrazyShop:** Fix Laser protection and kb protection items
- **Fog:** Fix fog not being able to be turned on again when it gets turned off
- **GunGame:** Refactor the weapon equip system, rely on ZR new natives now, and also admins able to give weapons by the !give command
- **RedLightGreenLight**: Add missing settings command
- **DoubleJump**: Add missing settings command

- **Global:**
- Add `FunModes_RestartRound` function to properly restart rounds, by slaying players before terminating the round
- Check for the ammo sendprop index in plugin start
- Refactor the give grenades functions to macros